### PR TITLE
docs: Fix formatting on GitHub pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
     "sphinx_rtd_theme",
     "sphinx-pydantic",
 ]


### PR DESCRIPTION
Adds a .nojekyll file to the github pages output, meaning that `_static` is not ignored.