### PR TITLE
Use localhost as default broker IP address

### DIFF
--- a/astoria.toml
+++ b/astoria.toml
@@ -1,7 +1,7 @@
 # Astoria Default Config File
 
 [mqtt]
-host = "test.mosquitto.org"
+host = "::1"
 port = 1883
 enable_tls = false
 force_protocol_version_3_1 = false


### PR DESCRIPTION
This makes the example configuration file suitable for use in packaging