### PR TITLE
debian: Add out-of-distro packages to py3dist-overrides

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,0 +1,3 @@
+dbus_next python3-dbus-next
+gmqtt python3-gmqtt
+pydantic python3-pydantic


### PR DESCRIPTION
Fixes #46 