### PR TITLE
astprocd: Log warnings to user accessible locations

### DIFF
--- a/astoria/managers/astprocd.py
+++ b/astoria/managers/astprocd.py
@@ -193,6 +193,10 @@ class ProcessManager(DiskHandlerMixin, StateManager[ProcessManagerMessage]):
             )
 
 
+class InvalidCodeBundleException(Exception):
+    """The code bundle was not valid."""
+
+
 class UsercodeLifecycle:
     """
     Manages the lifecycle of usercode.
@@ -246,7 +250,7 @@ class UsercodeLifecycle:
         self._dir = TemporaryDirectory(prefix="astprocd-")
         self._dir_path = Path(self._dir.name)
 
-    def _extract_and_validate_zip_file(self) -> bool:
+    def _extract_and_validate_zip_file(self) -> Optional[str]:
         """
         Extract and validate a robot.zip file.
 
@@ -254,78 +258,61 @@ class UsercodeLifecycle:
         robot.zip file. It will overwrite the current temporary dir
         of the usercode lifecycle, and should not be called multiple
         times.
+
+        :returns: optional message to print in the log file
         """
-
-        def _handle_error(error: str) -> None:
-            """
-            Handle an error with the zip file.
-
-            Logs to the astprocd logger and also writes
-            a log file to the usercode disk.
-            """
-            with self._disk_info.mount_path.joinpath("log.txt").open("w") as fh:
-                LOGGER.warning(error)
-                fh.write("Unable to start code.\n")
-                fh.write(f"{error}.\n")
-
         zip_path = self._disk_info.mount_path / "robot.zip"
 
         if not (zip_path.exists() and zip_path.is_file()):
-            _handle_error("Unable to find robot.zip file")
-            return False
+            raise InvalidCodeBundleException("Unable to find robot.zip file")
 
         try:
             with ZipFile(zip_path, "r") as zf:
                 zf.extractall(self._dir_path)
         except BadZipFile:
-            _handle_error("The provided robot.zip is not a valid ZIP archive")
-            return False
+            raise InvalidCodeBundleException(
+                "The provided robot.zip is not a valid ZIP archive",
+            )
 
         # Check that main.py is present
         exe_path = self._dir_path / "main.py"
         if not exe_path.exists():
-            _handle_error("The provided robot.zip did not contain a main.py")
-            return False
+            raise InvalidCodeBundleException(
+                "The provided robot.zip did not contain a main.py",
+            )
 
         LEGACY_FILES: Set[str] = {"info.yaml", "info.yml", "wifi.yaml", "wifi.yml"}
 
         for legacy_file in LEGACY_FILES:
             legacy_info_path = self._dir_path / legacy_file
             if legacy_info_path.exists():
-                _handle_error(
-                    "This is an old robot code package and"
-                    "will not work with this version of the kit.",
+                raise InvalidCodeBundleException(
+                    "This is an old robot code package and \
+                    will not work with this version of the kit.",
                 )
-                return False
 
         # Check for code bundle info
         bundle_meta_path = self._dir_path / "bundle.toml"
         if not bundle_meta_path.exists():
-            _handle_error("The provided robot.zip did not contain a bundle.toml")
-            return False
+            raise InvalidCodeBundleException(
+                "The provided robot.zip did not contain a bundle.toml",
+            )
         else:
             # Validate code bundle info
             try:
                 bundle_contents = toml.loads(bundle_meta_path.read_text())
             except toml.TomlDecodeError as e:
-                _handle_error(f"The code bundle was invalid.\n{e}")
-                return False
+                raise InvalidCodeBundleException(f"The code bundle was invalid.\n{e}")
 
             try:
                 bundle = CodeBundle(**bundle_contents)
             except ValidationError as e:
-                _handle_error(f"The code bundle was invalid.\n{e}")
-                return False
+                raise InvalidCodeBundleException(f"The code bundle was invalid.\n{e}")
 
             try:
-                message = bundle.check_kit_version_is_compatible(self._config.kit)
-                if message is not None:
-                    print(message)
+                return bundle.check_kit_version_is_compatible(self._config.kit)
             except IncompatibleKitVersionException as e:
-                _handle_error(f"Invalid code bundle: {e}")
-                return False
-
-        return True
+                raise InvalidCodeBundleException(f"Invalid code bundle: {e}")
 
     async def run_process(self) -> None:
         """
@@ -334,9 +321,8 @@ class UsercodeLifecycle:
         This function will not return until the code has exited.
         """
         if self._process is None:
-
-            if self._extract_and_validate_zip_file():
-
+            try:
+                log_message = self._extract_and_validate_zip_file()
                 async with self._process_lock:
                     self._process = await asyncio.create_subprocess_exec(
                         "python3",
@@ -379,10 +365,16 @@ class UsercodeLifecycle:
                         self._dir.cleanup()  # Reset directory
                         self._setup_temp_dir()
                     else:
-                        LOGGER.warning("robot.zip was invalid. Unable to start code.")
+                        LOGGER.warning("Tried to start process, but failed.")
                         self.status = CodeStatus.CRASHED  # Close enough to indicate error
-            else:
-                LOGGER.warning("Tried to start process, but failed.")
+            except InvalidCodeBundleException as e:
+                LOGGER.warning("robot.zip was invalid. Unable to start code.")
+                # Write error message to the log file.
+                with self._disk_info.mount_path.joinpath("log.txt").open("w") as fh:
+                    LOGGER.warning(str(e))
+                    fh.write("Unable to start code.\n")
+                    fh.write(f"{e}.\n")
+
                 self.status = CodeStatus.CRASHED  # Close enough to indicate error
         else:
             LOGGER.warning("Tried to start process, but one is already running.")

--- a/tests/common/test_bundle.py
+++ b/tests/common/test_bundle.py
@@ -85,7 +85,7 @@ def test_valid_versions_are_accepted(system, bundle) -> None:
     bundle_info = load_bundle("valid.toml")
     bundle_info.kit.version = bundle
 
-    assert bundle_info.check_kit_version_is_compatible(system_info) is None
+    assert len(bundle_info.check_kit_version_is_compatible(system_info)) == 0
 
 
 INCOMPATIBLE_SYSTEM_BUNDLE_VERSION_PAIRS = [
@@ -120,9 +120,9 @@ def test_kit_dev_message_is_added_when_dev_build() -> None:
     system_info = KitInfo(name="Astoria Development", version="0.0.0.0dev")
     bundle_info = load_bundle("valid.toml")
 
-    message = bundle_info.check_kit_version_is_compatible(system_info)
-    assert message is not None
-    assert "DEVELOPMENT BUILD" in message
+    messages = bundle_info.check_kit_version_is_compatible(system_info)
+    assert len(messages) == 1
+    assert "DEVELOPMENT BUILD" in messages[0]
 
 
 def test_kit_dev_message_is_not_added_on_prod_build() -> None:
@@ -130,8 +130,8 @@ def test_kit_dev_message_is_not_added_on_prod_build() -> None:
     system_info = KitInfo(name="Astoria Development", version="0.0.0.0")
     bundle_info = load_bundle("valid.toml")
 
-    message = bundle_info.check_kit_version_is_compatible(system_info)
-    assert message is None
+    messages = bundle_info.check_kit_version_is_compatible(system_info)
+    assert len(messages) == 0
 
 
 VERSION_DIFF_MESSAGES = [
@@ -159,5 +159,5 @@ def test_kit_warns_on_version_diff(system, bundle, expected_message) -> None:
     bundle_info = load_bundle("valid.toml")
     bundle_info.kit.version = bundle
 
-    message = bundle_info.check_kit_version_is_compatible(system_info)
-    assert expected_message in message
+    messages = bundle_info.check_kit_version_is_compatible(system_info)
+    assert expected_message in "\n".join(messages)

--- a/tests/managers/astprocd/test_usercode_lifecycle.py
+++ b/tests/managers/astprocd/test_usercode_lifecycle.py
@@ -203,6 +203,7 @@ async def test_run_with_bad_zip() -> None:
     Checks that:
     - Status message is written to the log file
     - The correct status is passed to the state manager
+    - Development indicator is printed
     """
     ucl, sith = StatusInformTestHelper.setup(EXTRACT_ZIP_DATA / "bad_zip")
     await ucl.run_process()
@@ -221,6 +222,7 @@ async def test_run_with_not_python() -> None:
     - Zip file is extracted and main.py is run
     - Output is written to the log file
     - The correct status is passed to the state manager
+    - Development indicator is printed
     """
     ucl, sith = StatusInformTestHelper.setup(EXECUTE_CODE_DATA / "not_python")
     await ucl.run_process()
@@ -234,8 +236,9 @@ async def test_run_with_not_python() -> None:
     log_file = EXECUTE_CODE_DATA / "not_python" / "log.txt"
     with ReadAndCleanupFile(log_file) as fh:
         lines = fh.read().splitlines()
-    assert lines[0] == "=== LOG STARTED ==="
-    assert "This is not a python program" in lines[2]
+    assert lines[0] == "WARNING: Running on DEVELOPMENT BUILD"
+    assert lines[1] == "=== LOG STARTED ==="
+    assert "This is not a python program" in lines[3]
     assert lines[-1] == "=== LOG FINISHED ==="
 
     assert lines == sith.log_helper.get_lines()
@@ -250,6 +253,7 @@ async def test_run_with_syntax_error() -> None:
     - Zip file is extracted and main.py is run
     - Output is written to the log file
     - The correct status is passed to the state manager
+    - Development indicator is printed
     """
     ucl, sith = StatusInformTestHelper.setup(EXECUTE_CODE_DATA / "syntax_error")
     await ucl.run_process()
@@ -263,8 +267,9 @@ async def test_run_with_syntax_error() -> None:
     log_file = EXECUTE_CODE_DATA / "syntax_error" / "log.txt"
     with ReadAndCleanupFile(log_file) as fh:
         lines = fh.read().splitlines()
-    assert lines[0] == "=== LOG STARTED ==="
-    assert "SyntaxError" in lines[4]
+    assert lines[0] == "WARNING: Running on DEVELOPMENT BUILD"
+    assert lines[1] == "=== LOG STARTED ==="
+    assert "SyntaxError" in lines[5]
     assert lines[-1] == "=== LOG FINISHED ==="
 
     assert lines == sith.log_helper.get_lines()
@@ -292,8 +297,9 @@ async def test_run_with_valid_python_wait_finish() -> None:
     log_file = EXECUTE_CODE_DATA / "valid_python_short" / "log.txt"
     with ReadAndCleanupFile(log_file) as fh:
         lines = fh.read().splitlines()
-    assert lines[0] == "=== LOG STARTED ==="
-    assert lines[1] == "Hello World"
+    assert lines[0] == "WARNING: Running on DEVELOPMENT BUILD"
+    assert lines[1] == "=== LOG STARTED ==="
+    assert lines[2] == "Hello World"
     assert lines[-1] == "=== LOG FINISHED ==="
 
     assert lines == sith.log_helper.get_lines()


### PR DESCRIPTION
Fixes #63

- Uses exceptions to handle warnings in code bundle
- Print them into the logs
- Test them