### PR TITLE
consumer: remove name_prefix abstract method

### DIFF
--- a/astoria/common/consumer.py
+++ b/astoria/common/consumer.py
@@ -1,8 +1,7 @@
 """State Consumer base class."""
 import asyncio
 import logging
-from abc import ABCMeta, abstractmethod
-from uuid import uuid4
+from abc import ABCMeta
 
 from .data_component import DataComponent
 
@@ -17,21 +16,6 @@ class StateConsumer(DataComponent, metaclass=ABCMeta):
 
     A process that accesses some state.
     """
-
-    @property
-    def name(self) -> str:
-        """
-        MQTT client name of the data component.
-
-        This should be unique, as clashes will cause unexpected disconnections.
-        """
-        return f"{self.name_prefix}-{uuid4()}"
-
-    @property
-    @abstractmethod
-    def name_prefix(self) -> str:
-        """Prefix for the non-random bit of the client name."""
-        raise NotImplementedError
 
     async def _post_connect(self) -> None:
         """Overridable callback after MQTT connection."""

--- a/astoria/consumers/astctl/command.py
+++ b/astoria/consumers/astctl/command.py
@@ -3,6 +3,7 @@ import asyncio
 from abc import abstractmethod
 from json import JSONDecodeError, loads
 from typing import Generic, Match, Type, TypeVar
+from uuid import uuid4
 
 from astoria.common.consumer import StateConsumer
 from astoria.common.messages.base import ManagerMessage
@@ -19,7 +20,14 @@ class Command(StateConsumer):
     Disables the welcome message from the logger.
     """
 
-    name_prefix = "astctl"
+    @property
+    def name(self) -> str:
+        """
+        MQTT client name of the data component.
+
+        This should be unique, as clashes will cause unexpected disconnections.
+        """
+        return f"astctl-{uuid4()}"
 
     def _setup_logging(self, verbose: bool, *, welcome_message: bool = True) -> None:
         super()._setup_logging(verbose, welcome_message=False)


### PR DESCRIPTION
This means that consumers can now have persistent names, which will be
required for any consumer that runs as a daemon (e.g astwifid)