### PR TITLE
astctl: Sort output of metadata show

### DIFF
--- a/astoria/consumers/astctl/metadata/show.py
+++ b/astoria/consumers/astctl/metadata/show.py
@@ -31,5 +31,5 @@ class ShowMetadataCommand(SingleManagerMessageCommand[MetadataManagerMessage]):
     ) -> None:
         """Print the metadata."""
         print("Current Astoria Metadata is:")
-        for i, v in message.metadata.__dict__.items():
+        for i, v in sorted(message.metadata.__dict__.items()):
             print(f"\t{i}: {v}")


### PR DESCRIPTION
Fixes #29

```
$ astctl metadata show                                                                                                                      
Current Astoria Metadata is:
        arch: x86_64
        arena: A
        astoria_version: 0.2.0
        game_timeout: None
        kernel_version: 5.10.35-1-lts
        kit_name: Astoria Development
        kit_version: 0.0.0.0dev
        libc_ver: glibc2.33
        mode: RobotMode.DEV
        python_version: 3.9.5
        wifi_enabled: True
        wifi_password: None
        wifi_ssid: None
        zone: 0
```