### PR TITLE
astwifid: Enable MFP for WPA3

### DIFF
--- a/astoria/consumers/astwifid.py
+++ b/astoria/consumers/astwifid.py
@@ -179,6 +179,8 @@ class WiFiHotspotLifeCycle:
             # Set of accepted key management algorithms
             "wpa_key_mgmt": "SAE WPA-PSK",  # SAE = WPA3, WPA-PSK = WPA2
             "wpa_passphrase": self._psk,
+            "ieee80211w": 2,
+            "sae_require_mfp": 1,
         }
         contents = "\n".join(f"{k}={v}" for k, v in config.items())
 

--- a/tests/data/hostapd/config.txt
+++ b/tests/data/hostapd/config.txt
@@ -8,3 +8,5 @@ auth_algs=1
 wpa_pairwise=CCMP
 wpa_key_mgmt=SAE WPA-PSK
 wpa_passphrase=pskpskpskpsk
+ieee80211w=2
+sae_require_mfp=1


### PR DESCRIPTION
Management Frame Protection (MFP / IEEE 802.11w) is a mandatory requirement for both the client and the AP when using WPA3. Most devices will refuse to connect without it.