### PR TITLE
astprocd: Recalculate time_passed before outputting log finish message

### DIFF
--- a/astoria/managers/astprocd.py
+++ b/astoria/managers/astprocd.py
@@ -479,6 +479,7 @@ class UsercodeLifecycle:
                 read_from_stream(proc_outputs, LogEventSource.STDOUT, log_line),
                 read_from_stream(proc_outputs, LogEventSource.STDERR, log_line),
             )
+            time_passed = datetime.now() - start_time
             log(f"[{time_passed}] === LOG FINISHED ===\n", log_line)
 
 


### PR DESCRIPTION
This prevents the end of log output from looking like this:
```
[0:00:02.665918] PowerBoard(SERIAL): Setting output 5 to False
[0:00:02.668290] MotorBoard(SERIAL): Setting motor 0 to BRAKE.
[0:00:02.670544] MotorBoard(SERIAL): Setting motor 1 to BRAKE.
[0:00:00.006757] === LOG FINISHED ===
