### PR TITLE
astmetad: Allow cache directory to be configured.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ modules.xml
 .vscode
 setup.py
 README.rst
+.cache_dir/

--- a/astoria.toml
+++ b/astoria.toml
@@ -16,3 +16,6 @@ version = "0.0.0.0dev"
 interface = "wlan0"
 bridge = "br0"
 enable_wpa3 = false
+
+[system]
+cache_dir = ".cache_dir"  # Use a directory in /var for production

--- a/astoria/common/config.py
+++ b/astoria/common/config.py
@@ -61,12 +61,24 @@ class WiFiInfo(BaseModel):
         extra = "forbid"
 
 
+class SystemInfo(BaseModel):
+    """System settings that don't find elsewhere."""
+
+    cache_dir: Path
+
+    class Config:
+        """Pydantic config."""
+
+        extra = "forbid"
+
+
 class AstoriaConfig(BaseModel):
     """Config schema for Astoria."""
 
     mqtt: MQTTBrokerInfo
     kit: KitInfo
     wifi: WiFiInfo
+    system: SystemInfo
 
     class Config:
         """Pydantic config."""

--- a/astoria/managers/astmetad/metadata_manager.py
+++ b/astoria/managers/astmetad/metadata_manager.py
@@ -47,7 +47,10 @@ class MetadataManager(DiskHandlerMixin, StateManager[MetadataManagerMessage]):
             disk_type: None
             for disk_type in self.DISK_TYPE_LIFECYCLE_MAP
         }
-        self._cache = MetadataCache(self.CACHED_ATTRS)
+        self._cache = MetadataCache(
+            self.CACHED_ATTRS,
+            cache_path=self.config.system.cache_dir / "astmetad-metadata.json",
+        )
 
         self._cur_disks: Dict[DiskUUID, DiskInfo] = {}
         self._mqtt.subscribe("astdiskd", self.handle_astdiskd_disk_info_message)

--- a/tests/data/config/missing_optional.toml
+++ b/tests/data/config/missing_optional.toml
@@ -10,3 +10,6 @@ version = "0.0.0.0dev"
 interface = "wlan0"
 bridge = "br0"
 enable_wpa3 = true
+
+[system]
+cache_dir = ".cache_dir"


### PR DESCRIPTION
This means that you don't need to have `/var/srobo` on your computer to develop astoria. It also makes it a tad more configurable.