### PR TITLE
Fix static disk removal

### DIFF
--- a/astoria/managers/astdiskd/static.py
+++ b/astoria/managers/astdiskd/static.py
@@ -82,6 +82,7 @@ class StaticDiskProvider(DiskProvider):
                 if str(path) == str(request.path):
                     del self.disks[uuid]
                     LOGGER.info(f'Static disk {uuid} unmounted ({request.path})')
+                    await self._notify_coro()
                     return RequestResponse(
                         uuid=request.uuid,
                         success=True,
@@ -128,6 +129,7 @@ class StaticDiskProvider(DiskProvider):
                 reason='There are no static disks to remove.',
             )
         else:
+            await self._notify_coro()
             return RequestResponse(
                 uuid=request.uuid,
                 success=True,


### PR DESCRIPTION
- Do not change disks dictionary whilst iterating
- Cannot assign to `self.disks`, need to use `self._disks`
- Call notify coroutine when a static disk is removed

Fixes #104 