### PR TITLE
astctl: Only print content of log in usercode log command

### DIFF
--- a/astoria/consumers/astctl/usercode/log.py
+++ b/astoria/consumers/astctl/usercode/log.py
@@ -41,6 +41,6 @@ class ViewUsercodeLogCommand(Command):
             # timeout to ensure that the loop condition is checked.
             try:
                 ev = await asyncio.wait_for(self._log_event.wait_broadcast(), timeout=0.1)
-                print(ev)
+                print(ev.content)
             except asyncio.TimeoutError:
                 pass


### PR DESCRIPTION
Previously looks like `event_name='usercode_log' sender_name='astprocd' priority=36 pid=741 content='[0:00:18.086837] usb.core.USBError: [Errno 19] No such device (it may have been disconnected)\n' source=<LogEventSource.STDERR: 'stderr'>    `

Should look like `[0:00:18.086837] usb.core.USBError: [Errno 19] No such device (it may have been disconnected)`