### PR TITLE
Read user code entry point from robot-settings.toml

### DIFF
--- a/astoria.toml
+++ b/astoria.toml
@@ -13,5 +13,8 @@ interface = "wlan0"
 bridge = "br0"
 enable_wpa3 = false
 
+[astprocd]
+default_usercode_entrypoint = "robot.py"
+
 [system]
 cache_dir = ".cache_dir"  # Use a directory in /var for production

--- a/astoria/common/config.py
+++ b/astoria/common/config.py
@@ -50,11 +50,18 @@ class SystemInfo(BaseModel):
         extra = "forbid"
 
 
+class ProcessManagerInfo(BaseModel):
+    """Settings specifically for astprocd."""
+
+    default_usercode_entrypoint: str = "robot.py"
+
+
 class AstoriaConfig(BaseModel):
     """Config schema for Astoria."""
 
     mqtt: MQTTBrokerInfo
     wifi: WiFiInfo
+    astprocd: ProcessManagerInfo = ProcessManagerInfo()  # Optional section
     system: SystemInfo
 
     class Config:

--- a/astoria/common/messages/astmetad.py
+++ b/astoria/common/messages/astmetad.py
@@ -46,6 +46,7 @@ class Metadata(BaseModel):
             arch=uname.machine,
             python_version=platform.python_version(),
             libc_ver="".join(platform.libc_ver()),
+            usercode_entrypoint=config.astprocd.default_usercode_entrypoint,
         )
 
     def is_wifi_valid(self) -> bool:
@@ -77,7 +78,8 @@ class Metadata(BaseModel):
     python_version: str
     libc_ver: str
 
-    # From astoria.toml
+    # From robot settings file
+    usercode_entrypoint: str
     wifi_ssid: Optional[str] = None
     wifi_psk: Optional[str] = None
     wifi_region: Optional[str] = None
@@ -87,6 +89,7 @@ class RobotSettings(BaseModel):
     """Schema for robot-settings.toml."""
 
     team_tla: str
+    usercode_entrypoint: str
     wifi_psk: str
     wifi_region: str = "GB"  # Assume GB as that is where most competitors are.
     wifi_enabled: bool = True
@@ -114,7 +117,7 @@ class RobotSettings(BaseModel):
         return val.upper()
 
     @classmethod
-    def generate_default_settings(cls) -> 'RobotSettings':
+    def generate_default_settings(cls, config: AstoriaConfig) -> 'RobotSettings':
         """Generate default sensible settings for the robot."""
         random_tla = f"ZZZ{random.randint(0, 99999)}"
 
@@ -127,6 +130,7 @@ class RobotSettings(BaseModel):
 
         return cls(
             team_tla=random_tla,
+            usercode_entrypoint=config.astprocd.default_usercode_entrypoint,
             wifi_psk=passphrase,
         )
 

--- a/astoria/managers/astmetad/metadata_manager.py
+++ b/astoria/managers/astmetad/metadata_manager.py
@@ -35,7 +35,7 @@ class MetadataManager(DiskHandlerMixin, StateManager[MetadataManagerMessage]):
     }
 
     DISK_TYPE_OVERRIDE_MAP: Dict[DiskType, Set[str]] = {
-        DiskType.USERCODE: {"wifi_ssid", "wifi_psk", "wifi_region", "wifi_enabled"},
+        DiskType.USERCODE: {"usercode_entrypoint", "wifi_ssid", "wifi_psk", "wifi_region", "wifi_enabled"},
         DiskType.METADATA: {
             "arena", "zone", "mode", "marker_offset", "game_timeout", "wifi_enabled",
         },
@@ -98,7 +98,11 @@ class MetadataManager(DiskHandlerMixin, StateManager[MetadataManagerMessage]):
                 )
                 if self._lifecycles[disk_type] is None:
                     LOGGER.debug(f"Starting lifecycle for {uuid}")
-                    self._lifecycles[disk_type] = lifecycle_class(uuid, disk_info)
+                    self._lifecycles[disk_type] = lifecycle_class(
+                        uuid,
+                        disk_info,
+                        self.config,
+                    )
                     self.update_status()
                 else:
                     LOGGER.warn(

--- a/astoria/managers/astmetad/metadata_manager.py
+++ b/astoria/managers/astmetad/metadata_manager.py
@@ -35,7 +35,10 @@ class MetadataManager(DiskHandlerMixin, StateManager[MetadataManagerMessage]):
     }
 
     DISK_TYPE_OVERRIDE_MAP: Dict[DiskType, Set[str]] = {
-        DiskType.USERCODE: {"usercode_entrypoint", "wifi_ssid", "wifi_psk", "wifi_region", "wifi_enabled"},
+        DiskType.USERCODE: {
+            "usercode_entrypoint", "wifi_ssid",
+            "wifi_psk", "wifi_region", "wifi_enabled",
+        },
         DiskType.METADATA: {
             "arena", "zone", "mode", "marker_offset", "game_timeout", "wifi_enabled",
         },

--- a/tests/common/messages/test_astmetad.py
+++ b/tests/common/messages/test_astmetad.py
@@ -32,6 +32,7 @@ def test_metadata_fields() -> None:
         arch="x64",
         python_version="3",
         libc_ver="2.0",
+        usercode_entrypoint="robot.py",
         wifi_ssid="robot",
         wifi_psk="bees",
         wifi_region="GB",
@@ -48,12 +49,13 @@ def test_metadata_fields() -> None:
     assert metadata.arch == "x64"
     assert metadata.python_version == "3"
     assert metadata.libc_ver == "2.0"
+    assert metadata.usercode_entrypoint == "robot.py"
     assert metadata.wifi_ssid == "robot"
     assert metadata.wifi_psk == "bees"
     assert metadata.wifi_region == "GB"
 
     assert metadata.json() == '{"arena": "B", "zone": 12, "mode": "COMP", "marker_offset": 40, "game_timeout": 120, "wifi_enabled": false, "astoria_version": "0.0.0", "kernel_version": "5.0.0", "arch": "x64", ' + \
-        '"python_version": "3", "libc_ver": "2.0", "wifi_ssid": "robot", "wifi_psk": "bees", "wifi_region": "GB"}'  # noqa: E501
+        '"python_version": "3", "libc_ver": "2.0", "usercode_entrypoint": "robot.py", "wifi_ssid": "robot", "wifi_psk": "bees", "wifi_region": "GB"}'  # noqa: E501
 
 
 def test_metadata_fields_default() -> None:
@@ -64,6 +66,7 @@ def test_metadata_fields_default() -> None:
         arch="x64",
         python_version="3",
         libc_ver="2.0",
+        usercode_entrypoint="robot.py",
     )
 
     assert metadata.arena == "A"
@@ -76,6 +79,7 @@ def test_metadata_fields_default() -> None:
     assert metadata.arch == "x64"
     assert metadata.python_version == "3"
     assert metadata.libc_ver == "2.0"
+    assert metadata.usercode_entrypoint == "robot.py"
     assert metadata.wifi_ssid is None
     assert metadata.wifi_psk is None
 
@@ -101,6 +105,7 @@ def test_metadata_manager_message_fields() -> None:
         arch="x64",
         python_version="3",
         libc_ver="2.0",
+        usercode_entrypoint="robot.py",
     )
 
     mmm = MetadataManagerMessage(

--- a/tests/managers/astprocd/test_usercode_lifecycle.py
+++ b/tests/managers/astprocd/test_usercode_lifecycle.py
@@ -10,6 +10,7 @@ import pytest
 from astoria.common.broadcast_event import UsercodeLogBroadcastEvent
 from astoria.common.config import AstoriaConfig
 from astoria.common.messages.astdiskd import DiskInfo, DiskType, DiskUUID
+from astoria.common.messages.astmetad import Metadata
 from astoria.common.messages.astprocd import CodeStatus
 from astoria.common.mqtt.broadcast_helper import BroadcastHelper, T
 from astoria.managers.astprocd.usercode_lifecycle import (
@@ -116,6 +117,7 @@ class StatusInformTestHelper:
             ),
             status_inform_callback=sith.callback,
             log_helper=sith.log_helper,
+            metadata=Metadata.init(config),
             config=config,
         )
         return ucl, sith


### PR DESCRIPTION
Fixes #114

Allows configuration of both a default entry point, and an override in `robot-settings.toml`.

### Robot Settings

```toml
team_tla = "ZZZ62643"
usercode_entrypoint = "robot.py"
wifi_psk = "ae12-6dfe-9e05"
wifi_region = "GB"
wifi_enabled = true
```

### Astoria.toml default

```toml
[astprocd]
default_usercode_entrypoint = "robot.py"
```

