### PR TITLE
astdiskd: Send an initial update on startup

### DIFF
--- a/astoria/managers/astdiskd/disk_manager.py
+++ b/astoria/managers/astdiskd/disk_manager.py
@@ -50,6 +50,9 @@ class DiskManager(StateManager[DiskManagerMessage]):
         for provider in self._providers:
             asyncio.ensure_future(provider.main())
 
+        # Send a disk manager update on startup so we don't wait for the first disk.
+        await self.update_state()
+
         # Wait whilst the program is running.
         await self.wait_loop()
 


### PR DESCRIPTION
Before this change, on systems without dbus and UDisks, astdiskd would simply just hang forever, which is not ideal.

On systems with dbus and Udisks, it would hang until the UdisksProvider updated.