### PR TITLE
Use pip for installing dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@ FROM python:3.9-slim as base
 
 WORKDIR /app
 
-RUN pip install dephell[full]
+RUN pip install --upgrade pip
 
 COPY docker/astoria.toml /etc/
 COPY astoria/ /app/astoria
 COPY pyproject.toml README.md /app/
-
-RUN dephell deps convert --from pyproject.toml --to setup.py
 
 RUN pip install .


### PR DESCRIPTION
dephell is deprecated and pip can now install from pyproject.toml