### PR TITLE
Calculate disk type in each component

### DIFF
--- a/astoria/astctl/list_disks.py
+++ b/astoria/astctl/list_disks.py
@@ -32,7 +32,7 @@ class ListDisksCommand(SingleManagerMessageCommand[DiskManagerMessage]):
     ) -> None:
         """Display information about the disks."""
         print(f"{len(message.disks)} disks found")
-        for uuid, disk in message.disks.items():
+        for uuid, disk in message.calculate_disk_info().items():
             print(f"\tUUID: {uuid}")
             print(f"\t\tMounted at: {disk.mount_path}")
             print(f"\t\tDisk Type: {disk.disk_type.name}")

--- a/astoria/astdiskd/disk_manager.py
+++ b/astoria/astdiskd/disk_manager.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import List
 
 from astoria.common.components import StateManager
-from astoria.common.disks import DiskInfo, DiskType
 from astoria.common.ipc import DiskManagerMessage
 
 from .disk_provider import DiskProvider
@@ -58,11 +57,7 @@ class DiskManager(StateManager[DiskManagerMessage]):
         disks = {}
         for provider in self._providers:
             for uuid, mount_path in provider.disks.items():
-                disks[uuid] = DiskInfo(
-                    uuid=uuid,
-                    mount_path=mount_path,
-                    disk_type=DiskType.determine_disk_type(mount_path),
-                )
+                disks[uuid] = mount_path
         self.status = DiskManagerMessage(
             status=DiskManagerMessage.Status.RUNNING,
             disks=disks,

--- a/astoria/common/disks/__init__.py
+++ b/astoria/common/disks/__init__.py
@@ -1,9 +1,11 @@
 """Code for recognising disk drives."""
 
 from .structs import DiskInfo, DiskType, DiskUUID
+from .type_calculator import DiskTypeCalculator
 
 __all__ = [
     "DiskInfo",
     "DiskType",
+    "DiskTypeCalculator",
     "DiskUUID",
 ]

--- a/astoria/common/disks/structs.py
+++ b/astoria/common/disks/structs.py
@@ -1,11 +1,9 @@
 """Struct definitions for astdiskd."""
 from enum import Enum
 from pathlib import Path
-from typing import Dict, NewType
+from typing import NewType
 
 from pydantic import BaseModel
-
-from .constraints import Constraint, FilePresentConstraint, TrueConstraint
 
 DiskUUID = NewType('DiskUUID', str)
 
@@ -17,22 +15,6 @@ class DiskType(Enum):
     METADATA = "METADATA"
     UPDATE = "UPDATE"
     NOACTION = "NOACTION"
-
-    @classmethod
-    def determine_disk_type(cls, mount_path: Path) -> 'DiskType':
-        """Determine the disk type from the mount path."""
-        constraints: Dict['DiskType', Constraint] = {
-            cls.USERCODE: FilePresentConstraint("robot.zip"),
-            cls.METADATA: FilePresentConstraint("astoria.json"),
-            cls.UPDATE: FilePresentConstraint("updatefile.txt"),
-            cls.NOACTION: TrueConstraint(),  # Always match
-        }
-
-        for typ, constraint in constraints.items():
-            if constraint.matches(mount_path):
-                return typ
-
-        raise RuntimeError("Unable to determine type of disk.")  # pragma: nocover
 
 
 class DiskInfo(BaseModel):

--- a/astoria/common/disks/type_calculator.py
+++ b/astoria/common/disks/type_calculator.py
@@ -1,0 +1,36 @@
+"""Class to determine the type of a disk."""
+
+from pathlib import Path
+from typing import Dict
+
+from .constraints import Constraint, FilePresentConstraint, TrueConstraint
+from .structs import DiskType
+
+
+class DiskTypeCalculator:
+    """
+    Helper class to calculate the DiskType of a given disk drive.
+
+    .. warning:: A disk must only rely on itself and not other disks to determine it
+             the type of the disk.
+    """
+
+    def calculate(self, path: Path) -> DiskType:
+        """
+        Calculate the DiskType of a drive given it's mount path.
+
+        :param path: The mount path of the drive.
+        :returns: The type of the disk.
+        """
+        constraints: Dict['DiskType', Constraint] = {
+            DiskType.USERCODE: FilePresentConstraint("robot.zip"),
+            DiskType.METADATA: FilePresentConstraint("astoria.json"),
+            DiskType.UPDATE: FilePresentConstraint("updatefile.txt"),
+            DiskType.NOACTION: TrueConstraint(),  # Always match
+        }
+
+        for typ, constraint in constraints.items():
+            if constraint.matches(path):
+                return typ
+
+        raise RuntimeError("Unable to determine type of disk.")  # pragma: nocover

--- a/astoria/common/mixins/disk_handler.py
+++ b/astoria/common/mixins/disk_handler.py
@@ -36,8 +36,9 @@ class DiskHandlerMixin:
                     info = self._cur_disks.pop(uuid)
                     asyncio.ensure_future(self.handle_disk_removal(uuid, info))
 
+                disk_info_dict = message.calculate_disk_info()
                 for uuid in added_disks:
-                    info = message.disks[uuid]
+                    info = disk_info_dict[uuid]
                     self._cur_disks[uuid] = info
                     asyncio.ensure_future(self.handle_disk_insertion(uuid, info))
             except JSONDecodeError:

--- a/tests/common/disks/test_structs.py
+++ b/tests/common/disks/test_structs.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 from astoria.common.disks import DiskInfo, DiskType, DiskUUID
 
-DATA_PATH = Path("tests/data/disk_types")
-
 
 def test_disk_type_enum() -> None:
     """Test that DiskType has the right values."""
@@ -13,19 +11,6 @@ def test_disk_type_enum() -> None:
     assert DiskType.UPDATE.value == "UPDATE"
     assert DiskType.USERCODE.value == "USERCODE"
     assert DiskType.METADATA.value == "METADATA"
-
-
-def test_disk_type_determination() -> None:
-    """Test that we can correctly determine the type of disk."""
-    expected_results = {
-        "metadata": DiskType.METADATA,
-        "noaction": DiskType.NOACTION,
-        "update": DiskType.UPDATE,
-        "usercode": DiskType.USERCODE,
-    }
-
-    for path, disk_type in expected_results.items():
-        assert DiskType.determine_disk_type(DATA_PATH / path) is disk_type
 
 
 def test_disk_info_fields() -> None:

--- a/tests/common/disks/test_type_calculator.py
+++ b/tests/common/disks/test_type_calculator.py
@@ -1,0 +1,22 @@
+"""Tests for astdiskd message definitions."""
+
+from pathlib import Path
+
+from astoria.common.disks import DiskType, DiskTypeCalculator
+
+DATA_PATH = Path("tests/data/disk_types")
+
+
+def test_disk_type_determination() -> None:
+    """Test that we can correctly determine the type of disk."""
+    expected_results = {
+        "metadata": DiskType.METADATA,
+        "noaction": DiskType.NOACTION,
+        "update": DiskType.UPDATE,
+        "usercode": DiskType.USERCODE,
+    }
+
+    calculator = DiskTypeCalculator()
+
+    for path, disk_type in expected_results.items():
+        assert calculator.calculate(DATA_PATH / path) is disk_type

--- a/tests/managers/mixins/test_disk_handler.py
+++ b/tests/managers/mixins/test_disk_handler.py
@@ -45,7 +45,7 @@ def get_disk_manager_message(names: List[str] = []) -> str:
     on set logic using the hash of the object.
     """
     return DiskManagerMessage(
-        disks=get_disk_info_list(names),
+        disks={DiskUUID(name): Path() for name in names},
         status=DiskManagerMessage.Status.RUNNING,
     ).json()
 


### PR DESCRIPTION
This patch removes the disk determination functionality from astdiskd, and moves it into each individual component.

This helps mitigate race conditions when disks change and opens the path for implementation of more complex disk determination.

Fixes #132