### PR TITLE
Use pydantic.parse_obj_as instead of BaseModel(**data)

### DIFF
--- a/astoria/astctl/command.py
+++ b/astoria/astctl/command.py
@@ -5,6 +5,8 @@ from json import JSONDecodeError, loads
 from typing import Generic, Match, Type, TypeVar
 from uuid import uuid4
 
+from pydantic import parse_obj_as
+
 from astoria.common.components import StateConsumer
 from astoria.common.ipc import ManagerMessage
 
@@ -78,7 +80,8 @@ class SingleManagerMessageCommand(Command, Generic[T]):
         if not self._received:
             self._received = True
             try:
-                message = self.message_schema(**loads(payload))
+                data = loads(payload)
+                message = parse_obj_as(self.message_schema, data)
                 if message.status == self.message_schema.Status.RUNNING:
                     self.handle_message(message)
                 else:

--- a/astoria/astprocd/process_manager.py
+++ b/astoria/astprocd/process_manager.py
@@ -5,6 +5,8 @@ import logging
 from json import JSONDecodeError, loads
 from typing import Dict, Match, Optional
 
+from pydantic import parse_obj_as
+
 from astoria.common.code_status import CodeStatus
 from astoria.common.components import StateManager
 from astoria.common.disks import DiskInfo, DiskType, DiskUUID
@@ -86,7 +88,8 @@ class ProcessManager(DiskHandlerMixin, StateManager[ProcessManagerMessage]):
         """Handle disk info messages."""
         if payload:
             try:
-                message = MetadataManagerMessage(**loads(payload))
+                data = loads(payload)
+                message = parse_obj_as(MetadataManagerMessage, data)
                 self._recent_metadata = message.metadata
             except JSONDecodeError:
                 LOGGER.warning("Received bad JSON in disk manager message.")

--- a/astoria/astwifid.py
+++ b/astoria/astwifid.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import IO, Match, Optional
 
 import click
-from pydantic import ValidationError
+from pydantic import ValidationError, parse_obj_as
 
 from astoria.common.components import StateConsumer
 from astoria.common.ipc import MetadataManagerMessage
@@ -66,7 +66,8 @@ class WiFiHotspotDaemon(StateConsumer):
         """Event handler for metadata changes."""
         if payload:
             try:
-                metadata_manager_message = MetadataManagerMessage(**loads(payload))
+                data = loads(payload)
+                metadata_manager_message = parse_obj_as(MetadataManagerMessage, data)
                 await self.handle_metadata(metadata_manager_message.metadata)
             except ValidationError:
                 LOGGER.warning("Received bad metadata manager message.")

--- a/astoria/common/config/system.py
+++ b/astoria/common/config/system.py
@@ -6,7 +6,7 @@ Common to all components.
 from pathlib import Path
 from typing import IO, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, parse_obj_as
 from toml import load
 
 
@@ -97,4 +97,4 @@ class AstoriaConfig(BaseModel):
     @classmethod
     def load_from_file(cls, fh: IO[str]) -> 'AstoriaConfig':
         """Load the config from a file."""
-        return cls(**load(fh))
+        return parse_obj_as(cls, load(fh))

--- a/astoria/common/config/user.py
+++ b/astoria/common/config/user.py
@@ -6,7 +6,7 @@ import secrets
 from pathlib import Path
 
 import toml
-from pydantic import BaseModel, ValidationError, validator
+from pydantic import BaseModel, ValidationError, parse_obj_as, validator
 
 from astoria.common.config import AstoriaConfig
 
@@ -85,7 +85,7 @@ class RobotSettings(BaseModel):
             raise NoValidRobotSettingsException("Invalid TOML")
 
         try:
-            return RobotSettings(**data)
+            return parse_obj_as(RobotSettings, data)
         except ValidationError as e:
             raise NoValidRobotSettingsException(
                 f"Settings did not match schema: {e}",

--- a/astoria/common/mqtt/broadcast_helper.py
+++ b/astoria/common/mqtt/broadcast_helper.py
@@ -4,6 +4,8 @@ from asyncio import PriorityQueue
 from json import JSONDecodeError, loads
 from typing import TYPE_CHECKING, Any, Generic, Match, Type, TypeVar
 
+from pydantic import parse_obj_as
+
 from astoria.common.ipc import BroadcastEvent
 
 if TYPE_CHECKING:
@@ -41,7 +43,7 @@ class BroadcastHelper(Generic[T]):
         Inserts the event inserts it into the priority queue.
         """
         try:
-            ev = self._schema(**loads(payload))
+            ev = parse_obj_as(self._schema, loads(payload))
             LOGGER.debug(
                 f"Received {ev.event_name} broadcast event from {ev.sender_name}",
             )

--- a/astoria/common/mqtt/wrapper.py
+++ b/astoria/common/mqtt/wrapper.py
@@ -16,7 +16,7 @@ from typing import (
 from uuid import UUID
 
 import gmqtt
-from pydantic import BaseModel
+from pydantic import BaseModel, parse_obj_as
 
 from astoria.common.config.system import MQTTBrokerInfo
 from astoria.common.ipc import ManagerMessage, ManagerRequest, RequestResponse
@@ -317,8 +317,9 @@ class MQTTWrapper:
         # If uuid not recognised, probably a response for another client
         if uuid in self._request_response_events:
             try:
-                self._request_response_data[uuid] = RequestResponse(
-                    **loads(payload),
+                self._request_response_data[uuid] = parse_obj_as(
+                    RequestResponse,
+                    loads(payload),
                 )
             except JSONDecodeError:
                 self._request_response_data[uuid] = RequestResponse(


### PR DESCRIPTION
This commit changes how we instantiate pydantic BaseModel objects and thus how we validate the data that astoria is handling.

Previously, we were unpacking the data into kwargs and passing it into the constructor: `MyModel(**data)`, which works fine in the case that the `data` object is a dictionary. However, we can also load other data types from JSON and TOML, such as lists:

```python
>>> a = [1, 2, 3]
>>> dict(**a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: dict() argument after ** must be a mapping, not list
```

Hence, there are potential runtime issues if we use this mechanism to create objects.

This commit changes to using `pydantic.parse_obj_as`, which safely handles objects that are not dictionaries.

Functionally, the code performs almost exactly the same.