### PR TITLE
Allow templating of metadata in initial_log_lines

### DIFF
--- a/astoria/astprocd/process_manager.py
+++ b/astoria/astprocd/process_manager.py
@@ -109,6 +109,7 @@ class ProcessManager(DiskHandlerMixin, StateManager[ProcessManagerMessage]):
                     self.update_status,
                     self._log_helper,
                     self.config,
+                    self._recent_metadata,
                 )
                 asyncio.ensure_future(self._lifecycle.run_process())
             else:

--- a/astoria/common/metadata.py
+++ b/astoria/common/metadata.py
@@ -17,7 +17,12 @@ class RobotMode(Enum):
 
 
 class Metadata(BaseModel):
-    """Astoria Metadata."""
+    """
+    Astoria Metadata.
+
+    As the metadata is passed into a templating engine for initial log lines, please do
+    not add nested fields to this schema.
+    """
 
     class Config:
         """Pydantic config."""


### PR DESCRIPTION
This change usings the string.Template templating engine to allow metadata to be inserted into the initial log lines at runtime.

This means that we can print the OS version and other information that Astoria is aware of in the log lines.

It should be noted that the metadata is the metadata at the time of the log being generated, so the arena, zone and other keys that may be updated by a metadata USB might not be accurate when the code first starts. This is because metadata USBs are often inserted after the robot has been turned on!

Fixes #156

This change also builds the path to #113, although doesn't resolve it until #163 is also merged.