### PR TITLE
Fix kill command immediately using SIGKILL

### DIFF
--- a/astoria/astprocd/usercode_lifecycle.py
+++ b/astoria/astprocd/usercode_lifecycle.py
@@ -159,12 +159,16 @@ class UsercodeLifecycle:
 
     async def kill_process(self) -> None:
         """Kill the process, if one is running."""
+        async def wait_for_exit() -> None:
+            while self._process is not None:
+                await asyncio.sleep(0.1)
+
         if self._process is not None and self._process_lock.locked():
             LOGGER.info("Attempting to kill process.")
 
             LOGGER.info(f"Sent SIGTERM to pid {self._process.pid}")
             self._process.send_signal(SIGTERM)
-            await asyncio.sleep(5.0)
+            await asyncio.wait_for(wait_for_exit(), timeout=5.0)
             try:
                 if self._process is not None:
                     LOGGER.info(f"Sent SIGKILL to pid {self._process.pid}")

--- a/astoria/astprocd/usercode_lifecycle.py
+++ b/astoria/astprocd/usercode_lifecycle.py
@@ -168,8 +168,9 @@ class UsercodeLifecycle:
 
             LOGGER.info(f"Sent SIGTERM to pid {self._process.pid}")
             self._process.send_signal(SIGTERM)
-            await asyncio.wait_for(wait_for_exit(), timeout=5.0)
             try:
+                await asyncio.wait_for(wait_for_exit(), timeout=5.0)
+            except TimeoutError:
                 if self._process is not None:
                     LOGGER.info(f"Sent SIGKILL to pid {self._process.pid}")
                     self._process.send_signal(SIGKILL)

--- a/astoria/astprocd/usercode_lifecycle.py
+++ b/astoria/astprocd/usercode_lifecycle.py
@@ -170,7 +170,7 @@ class UsercodeLifecycle:
             self._process.send_signal(SIGTERM)
             try:
                 await asyncio.wait_for(wait_for_exit(), timeout=5.0)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 if self._process is not None:
                     LOGGER.info(f"Sent SIGKILL to pid {self._process.pid}")
                     self._process.send_signal(SIGKILL)

--- a/astoria/astprocd/usercode_lifecycle.py
+++ b/astoria/astprocd/usercode_lifecycle.py
@@ -162,14 +162,10 @@ class UsercodeLifecycle:
         if self._process is not None and self._process_lock.locked():
             LOGGER.info("Attempting to kill process.")
 
-            # Work-around for bpo-43884
-            self._process._transport.close()  # type: ignore
-
             LOGGER.info(f"Sent SIGTERM to pid {self._process.pid}")
             self._process.send_signal(SIGTERM)
+            await asyncio.sleep(5.0)
             try:
-                await asyncio.wait_for(self._process.communicate(), timeout=5.0)
-            except asyncio.TimeoutError:
                 if self._process is not None:
                     LOGGER.info(f"Sent SIGKILL to pid {self._process.pid}")
                     self._process.send_signal(SIGKILL)


### PR DESCRIPTION
Closing the transport sends sigkill to the process which causes the process to end immediately without cleanup. This leaves the transport open and just waits up to 5 seconds for the process to exit after SIGTERM before sending SIGKILL.

Because there are other async tasks communicating with the process we cannot use process.communicate()

This does not totally fix the issue with make_safe not running when the code is killed but the rest of the fix will be implemented in sr-robot3.