### PR TITLE
astctl: Strip spurious newlines from log messages

### DIFF
--- a/astoria/astctl/usercode/log.py
+++ b/astoria/astctl/usercode/log.py
@@ -41,6 +41,6 @@ class ViewUsercodeLogCommand(Command):
             # timeout to ensure that the loop condition is checked.
             try:
                 ev = await asyncio.wait_for(self._log_event.wait_broadcast(), timeout=0.1)
-                print(ev.content)
+                print(ev.content.rstrip())
             except asyncio.TimeoutError:
                 pass


### PR DESCRIPTION
We're adding our own newlines with print. This makes the gaps go away