### PR TITLE
Refactor astwifid

### DIFF
--- a/astoria/astwifid/__init__.py
+++ b/astoria/astwifid/__init__.py
@@ -1,0 +1,22 @@
+"""Wifi Daemon - Handles Hotspot and WiFi Client connection."""
+import asyncio
+from typing import Optional
+
+import click
+
+from .wifi_manager import WiFiManager
+
+loop = asyncio.get_event_loop()
+
+
+@click.command("astwifid")
+@click.option("-v", "--verbose", is_flag=True)
+@click.option("-c", "--config-file", type=click.Path(exists=True))
+def main(*, verbose: bool, config_file: Optional[str]) -> None:
+    """The WiFi Manager Application Entrypoint."""
+    wifid = WiFiManager(verbose, config_file)
+    loop.run_until_complete(wifid.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/astoria/astwifid/hotspot_lifecycle.py
+++ b/astoria/astwifid/hotspot_lifecycle.py
@@ -10,52 +10,37 @@ import signal
 import tempfile
 from typing import IO, Optional
 
-from astoria.common.metadata import Metadata
+from astoria.common.config.system import WiFiInfo
+
+from .lifecycle import AccessPointInfo, WiFiLifecycle
 
 LOGGER = logging.getLogger(__name__)
 
 
-class WiFiHotspotLifeCycle:
+class WiFiHotspotLifeCycle(WiFiLifecycle):
     """Manages the lifecycle of the hostapd process."""
+
+    name = "WiFi Hotspot"
 
     HOSTAPD_BINARY: str = "hostapd"
 
     def __init__(
             self,
-            ssid: str,
-            psk: str,
-            region: str,
-            interface: str,
-            bridge: str,
-            enable_wpa3: bool,
+            access_point_info: AccessPointInfo,
+            wifi_info: WiFiInfo,
     ) -> None:
-        LOGGER.info("Starting WiFi Hotspot lifecycle")
-        self._ssid: str = ssid
-        self._psk: str = psk
-        self._region: str = region
-        self._interface: str = interface
-        self._bridge: str = bridge
-        self._enable_wpa3: bool = enable_wpa3
+        self._access_point_info = access_point_info
+        self._wifi_info = wifi_info
 
         self._config_file: Optional[IO[bytes]] = None
         self._proc: Optional[asyncio.subprocess.Process] = None
         self._running: bool = False
 
-    def has_metadata_changed(self, metadata: Metadata) -> bool:
-        """Checks if the hotspot's properties match that of a set of metadata."""
-        return not all(
-            [
-                self._ssid == metadata.wifi_ssid,
-                self._psk == metadata.wifi_psk,
-                self._region == metadata.wifi_region,
-            ],
-        )
-
-    async def run_hotspot(self) -> None:
+    async def run(self) -> None:
         """Starts the hostapd process."""
         self._running = True
-        LOGGER.info(f"Starting WiFi Hotspot \"{self._ssid}\" on {self._interface}")
-        self.generate_hostapd_config()
+        LOGGER.info(f"Starting WiFi Hotspot \"{self.ssid}\" on {self.interface}")
+        self._generate_hostapd_config()
         if self._config_file is not None:
             while self._running:
                 self._proc = await asyncio.create_subprocess_exec(
@@ -73,17 +58,17 @@ class WiFiHotspotLifeCycle:
                 "Tried to start hotspot, but the config file was not set.",
             )
 
-    def generate_hostapd_config(self) -> None:
+    def _generate_hostapd_config(self) -> None:
         """Generates a configuration file for hostapd based on the current metadata."""
         self._config_file = tempfile.NamedTemporaryFile(delete=False)
         LOGGER.debug(
             f"Writing {self.HOSTAPD_BINARY} configuration to {self._config_file.name}",
         )
         config = {
-            "interface": self._interface,
-            "bridge": self._bridge,
-            "ssid": self._ssid,
-            "country_code": self._region,
+            "interface": self._wifi_info.interface,
+            "bridge": self._wifi_info.bridge,
+            "ssid": self._access_point_info.ssid,
+            "country_code": self._access_point_info.region,
             "channel": 6,
             "hw_mode": "g",
             # Bit field: bit0 = WPA, bit1 = WPA2
@@ -95,10 +80,10 @@ class WiFiHotspotLifeCycle:
             # Set of accepted key management algorithms
             # SAE = WPA3, WPA-PSK = WPA2
             "wpa_key_mgmt": "WPA-PSK",
-            "wpa_passphrase": self._psk,
+            "wpa_passphrase": self.access_point_info.psk,
         }
 
-        if self._enable_wpa3:
+        if self.wifi_info.enable_wpa3:
             config["wpa_key_mgmt"] = "SAE WPA-PSK"
             # Management frame support (802.11w)
             # Most client devices will not connect to a
@@ -112,7 +97,7 @@ class WiFiHotspotLifeCycle:
         self._config_file.write(contents.encode())
         self._config_file.close()
 
-    async def stop_hotspot(self) -> None:
+    async def stop(self) -> None:
         """Stops the hostapd process."""
         self._running = False
         LOGGER.info("Stopping WiFi Hotspot")

--- a/astoria/astwifid/lifecycle.py
+++ b/astoria/astwifid/lifecycle.py
@@ -1,0 +1,79 @@
+"""Definition for a WiFi lifecycle."""
+from abc import ABCMeta, abstractmethod
+from typing import NamedTuple
+
+from astoria.common.config.system import WiFiInfo
+
+
+class AccessPointInfo(NamedTuple):
+    """The information required for an Access Point."""
+
+    ssid: str
+    psk: str
+    region: str
+
+
+class WiFiLifecycle(metaclass=ABCMeta):
+    """A lifecycle that can be executed by astwifid."""
+
+    _access_point_info: AccessPointInfo
+    _wifi_info: WiFiInfo
+
+    def __init__(
+        self,
+        access_point_info: AccessPointInfo,
+        wifi_info: WiFiInfo,
+    ) -> None:
+        self._access_point_info = access_point_info
+        self._wifi_info = wifi_info
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """The name of the lifecycle."""
+        raise NotImplementedError  # pragma: nocover
+
+    @property
+    def access_point_info(self) -> AccessPointInfo:
+        """The access point info for the lifecycle."""
+        return self._access_point_info
+
+    @property
+    def wifi_info(self) -> WiFiInfo:
+        """The WiFi hardware info for the lifecycle."""
+        return self._wifi_info
+
+    @property
+    def ssid(self) -> str:
+        """The SSID of the network."""
+        return self.access_point_info.ssid
+
+    @property
+    def interface(self) -> str:
+        """The physical interface for the WiFi radio."""
+        return self.wifi_info.interface
+
+    def __eq__(self, __o: object) -> bool:
+        """
+        Determine equality of two lifecycle.
+
+        Lifecycles are equal if they are both the same class and have the same access
+        point details. This comparison is used to determine if a lifecycle needs to be
+        recreated when the metadata is updated.
+        """
+        access_point_info = getattr(__o, "access_point_info", None)
+        return type(__o) is type(self) and access_point_info == self.access_point_info
+
+    @abstractmethod
+    async def run(self) -> None:
+        """
+        Run the lifecycle.
+
+        This coroutine will exist for the lifetime of the lifecycle.
+        """
+        raise NotImplementedError  # pragma: nocover
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop the lifecycle."""
+        raise NotImplementedError  # pragma: nocover

--- a/astoria/astwifid/wifi_manager.py
+++ b/astoria/astwifid/wifi_manager.py
@@ -14,6 +14,7 @@ from astoria.common.metadata import Metadata
 from astoria.common.mixins import MetadataHandlerMixin
 
 from .hotspot_lifecycle import WiFiHotspotLifeCycle
+from .lifecycle import AccessPointInfo, WiFiLifecycle
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,8 @@ class WiFiManager(MetadataHandlerMixin, StateManager[WiFiManagerMessage]):
     dependencies = ["astmetad"]
 
     def _init(self) -> None:
-        self._hotspot_lifecycle: Optional[WiFiHotspotLifeCycle] = None
+        self._lifecycle_lock = asyncio.Lock()
+        self._lifecycle: Optional[WiFiLifecycle] = None
 
         self._mqtt.subscribe("astmetad", self.handle_astmetad_message)
 
@@ -40,8 +42,37 @@ class WiFiManager(MetadataHandlerMixin, StateManager[WiFiManagerMessage]):
         await self.wait_loop()
 
         # Stop the hotspot when we shutdown
-        if self._hotspot_lifecycle:
-            await self._hotspot_lifecycle.stop_hotspot()
+        async with self._lifecycle_lock:
+            if self._lifecycle:
+                await self._lifecycle.stop()
+
+    def _is_hardware_available(self) -> bool:
+        required_interfaces = [self.config.wifi.interface, self.config.wifi.bridge]
+        all_interfaces_available = all(
+            Path(f"/sys/class/net/{interface}").exists()
+            for interface in required_interfaces
+        )
+        if not all_interfaces_available:
+            LOGGER.warning("Some physical interfaces were not available.")
+        return all_interfaces_available
+
+    def _get_lifecycle(self, metadata: Metadata) -> Optional[WiFiLifecycle]:
+        hotspot_can_run = all([
+            metadata.wifi_enabled,
+            metadata.wifi_ssid is not None,
+            metadata.wifi_psk is not None,
+            metadata.wifi_region is not None,
+            self._is_hardware_available(),
+        ])
+        if hotspot_can_run:
+            # The types here are validated by the above if statement.
+            ap_info = AccessPointInfo(
+                metadata.wifi_ssid,  # type: ignore
+                metadata.wifi_psk,  # type: ignore
+                metadata.wifi_region,  # type: ignore
+            )
+            return WiFiHotspotLifeCycle(ap_info, self.config.wifi)
+        return None
 
     @property
     def offline_status(self) -> WiFiManagerMessage:
@@ -56,53 +87,52 @@ class WiFiManager(MetadataHandlerMixin, StateManager[WiFiManagerMessage]):
             hotspot_running=False,
         )
 
+    def _start_lifecycle(self, lifecycle: WiFiLifecycle) -> None:
+        """
+        Start a new WiFi lifecycle.
+
+        This function assumes that the caller already holds the lifecycle lock.
+        """
+        self._lifecycle = lifecycle
+        self.status = WiFiManagerMessage(
+            status=WiFiManagerMessage.Status.RUNNING,
+            hotspot_running=True,
+        )
+        asyncio.ensure_future(self._lifecycle.run())
+
     async def handle_metadata(self, metadata: Metadata) -> None:
         """
         Update the state of the hotspot based on the current metadata.
 
         :param metadata: The metadata included in the update.
         """
-        wifi_interface = Path(f"/sys/class/net/{self.config.wifi.interface}")
-        if self._hotspot_lifecycle:
-            if metadata.is_wifi_valid() and wifi_interface.exists():
-                if self._hotspot_lifecycle.has_metadata_changed(metadata):
-                    await self._hotspot_lifecycle.stop_hotspot()
-                    self._hotspot_lifecycle = WiFiHotspotLifeCycle(
-                        # The types here are checked by is_wifi_valid
-                        metadata.wifi_ssid,  # type: ignore
-                        metadata.wifi_psk,  # type: ignore
-                        metadata.wifi_region,  # type: ignore
-                        self.config.wifi.interface,
-                        self.config.wifi.bridge,
-                        self.config.wifi.enable_wpa3,
-                    )
+        LOGGER.debug("Received new metadata.")
+        async with self._lifecycle_lock:
+            new_lifecycle = self._get_lifecycle(metadata)
+            if self._lifecycle:
+                LOGGER.debug("A lifecycle already exists.")
+                if new_lifecycle:
+                    if self._lifecycle == new_lifecycle:
+                        LOGGER.debug("WiFi is setup as required, taking no actions.")
+                    else:
+                        LOGGER.info("WiFi details have changed. Restarting.")
+
+                        LOGGER.debug(f"Stopping existing {self._lifecycle.name}.")
+                        await self._lifecycle.stop()
+
+                        LOGGER.debug(f"Starting {new_lifecycle.name}.")
+                        self._start_lifecycle(new_lifecycle)
+                else:
+                    LOGGER.info(f"Stopping existing {self._lifecycle.name}.")
+                    await self._lifecycle.stop()
                     self.status = WiFiManagerMessage(
                         status=WiFiManagerMessage.Status.RUNNING,
-                        hotspot_running=True,
+                        hotspot_running=False,
                     )
-                    asyncio.ensure_future(self._hotspot_lifecycle.run_hotspot())
+                    self._lifecycle = None
             else:
-                # Turn it off!
-                await self._hotspot_lifecycle.stop_hotspot()
-                self.status = WiFiManagerMessage(
-                    status=WiFiManagerMessage.Status.RUNNING,
-                    hotspot_running=False,
-                )
-                self._hotspot_lifecycle = None
-        else:
-            if metadata.is_wifi_valid() and wifi_interface.exists():
-                # Turn it on!
-                self._hotspot_lifecycle = WiFiHotspotLifeCycle(
-                    # The types here are checked by is_wifi_valid
-                    metadata.wifi_ssid,  # type: ignore
-                    metadata.wifi_psk,  # type: ignore
-                    metadata.wifi_region,  # type: ignore
-                    self.config.wifi.interface,
-                    self.config.wifi.bridge,
-                    self.config.wifi.enable_wpa3,
-                )
-                self.status = WiFiManagerMessage(
-                    status=WiFiManagerMessage.Status.RUNNING,
-                    hotspot_running=True,
-                )
-                asyncio.ensure_future(self._hotspot_lifecycle.run_hotspot())
+                if new_lifecycle:
+                    LOGGER.debug(f"Starting {new_lifecycle.name}.")
+                    self._start_lifecycle(new_lifecycle)
+                else:
+                    LOGGER.debug("No WiFi is required, taking no actions.")

--- a/astoria/astwifid/wifi_manager.py
+++ b/astoria/astwifid/wifi_manager.py
@@ -1,0 +1,108 @@
+"""
+Astoria WiFi Daemon.
+
+Manages a WiFi hotspot for the robot.
+"""
+import asyncio
+import logging
+from pathlib import Path
+from typing import Optional
+
+from astoria.common.components import StateManager
+from astoria.common.ipc import WiFiManagerMessage
+from astoria.common.metadata import Metadata
+from astoria.common.mixins import MetadataHandlerMixin
+
+from .hotspot_lifecycle import WiFiHotspotLifeCycle
+
+LOGGER = logging.getLogger(__name__)
+
+
+class WiFiManager(MetadataHandlerMixin, StateManager[WiFiManagerMessage]):
+    """
+    WiFi Management Daemon.
+
+    Receives metadata information from astmetad and manages the WiFi.
+    """
+
+    name = "astwifid"
+
+    dependencies = ["astmetad"]
+
+    def _init(self) -> None:
+        self._hotspot_lifecycle: Optional[WiFiHotspotLifeCycle] = None
+
+        self._mqtt.subscribe("astmetad", self.handle_astmetad_message)
+
+    async def main(self) -> None:
+        """Main routine for astwifid."""
+        # Wait whilst the program is running.
+        await self.wait_loop()
+
+        # Stop the hotspot when we shutdown
+        if self._hotspot_lifecycle:
+            await self._hotspot_lifecycle.stop_hotspot()
+
+    @property
+    def offline_status(self) -> WiFiManagerMessage:
+        """
+        Status to publish when the manager goes offline.
+
+        This status should ensure that any other components relying
+        on this data go into a safe state.
+        """
+        return WiFiManagerMessage(
+            status=WiFiManagerMessage.Status.STOPPED,
+            hotspot_running=False,
+        )
+
+    async def handle_metadata(self, metadata: Metadata) -> None:
+        """
+        Update the state of the hotspot based on the current metadata.
+
+        :param metadata: The metadata included in the update.
+        """
+        wifi_interface = Path(f"/sys/class/net/{self.config.wifi.interface}")
+        if self._hotspot_lifecycle:
+            if metadata.is_wifi_valid() and wifi_interface.exists():
+                if self._hotspot_lifecycle.has_metadata_changed(metadata):
+                    await self._hotspot_lifecycle.stop_hotspot()
+                    self._hotspot_lifecycle = WiFiHotspotLifeCycle(
+                        # The types here are checked by is_wifi_valid
+                        metadata.wifi_ssid,  # type: ignore
+                        metadata.wifi_psk,  # type: ignore
+                        metadata.wifi_region,  # type: ignore
+                        self.config.wifi.interface,
+                        self.config.wifi.bridge,
+                        self.config.wifi.enable_wpa3,
+                    )
+                    self.status = WiFiManagerMessage(
+                        status=WiFiManagerMessage.Status.RUNNING,
+                        hotspot_running=True,
+                    )
+                    asyncio.ensure_future(self._hotspot_lifecycle.run_hotspot())
+            else:
+                # Turn it off!
+                await self._hotspot_lifecycle.stop_hotspot()
+                self.status = WiFiManagerMessage(
+                    status=WiFiManagerMessage.Status.RUNNING,
+                    hotspot_running=False,
+                )
+                self._hotspot_lifecycle = None
+        else:
+            if metadata.is_wifi_valid() and wifi_interface.exists():
+                # Turn it on!
+                self._hotspot_lifecycle = WiFiHotspotLifeCycle(
+                    # The types here are checked by is_wifi_valid
+                    metadata.wifi_ssid,  # type: ignore
+                    metadata.wifi_psk,  # type: ignore
+                    metadata.wifi_region,  # type: ignore
+                    self.config.wifi.interface,
+                    self.config.wifi.bridge,
+                    self.config.wifi.enable_wpa3,
+                )
+                self.status = WiFiManagerMessage(
+                    status=WiFiManagerMessage.Status.RUNNING,
+                    hotspot_running=True,
+                )
+                asyncio.ensure_future(self._hotspot_lifecycle.run_hotspot())

--- a/astoria/common/metadata.py
+++ b/astoria/common/metadata.py
@@ -110,20 +110,6 @@ class Metadata(BaseModel):
 
         return {}
 
-    def is_wifi_valid(self) -> bool:
-        """
-        Check if the WiFi configuration is valid to be turned on.
-
-        Checks that the WiFi is enabled and that the config params are set.Optional
-        :return: boolean indicating whether the WiFi can be turned on.
-        """
-        return all([
-            self.wifi_enabled,
-            self.wifi_ssid is not None,
-            self.wifi_psk is not None,
-            self.wifi_region is not None,
-        ])
-
     # From Meta USB
     arena: str = "A"
     zone: int = 0

--- a/docs/implementation/managers/astwifid.rst
+++ b/docs/implementation/managers/astwifid.rst
@@ -3,25 +3,34 @@ Astwifid
 
 Astwifid is responsible for:
 
-- Hosting a WiFi Access Point (AP) while the kit is running in development mode.
-- Configuring the WiFi network based on code bundle information.
-- Caching of WiFi configuration to allow the network to come up after a restart without the presence of a Usercode USB.
+* Hosting a WiFi Access Point (AP) while the kit is running in development mode.
+* Configuring the WiFi network based on code bundle information.
+* Caching of WiFi configuration to allow the network to come up after a restart without the presence of a Usercode USB.
 
 It is not responsible for handling any networking components such as DHCP. These are to be handled by the operating system.
 
-Hostapd is used to create the WiFi hotspot and uses a configuration that is dynamically generate and stored in ``/tmp``.
+Hostapd is used to create the WiFi hotspot and uses a configuration that is dynamically generated and stored in ``/tmp``.
 Hostapd is then launched as a child process of the astwifid process. This is managed via the ``asyncio.subprocess`` module.
 
- - Metadata is received from ref:`astmetad`
- - If ``wifi_enabled`` is True and other data is provided (``ssid``, ``psk``, ``region``), then the hotspot is started.
- - If the metadata changes, the hotspot will automatically restarted with updated credentials if required.
- - If ``wifi_enabled`` changes to False, then the hotspot will be killed.
+* Metadata is received from ref:`astmetad`
+* If ``wifi_enabled`` is True and other data is provided (``ssid``, ``psk``, ``region``), then the hotspot is started.
+* If the metadata changes, the hotspot will automatically restarted with updated credentials if required.
+* If ``wifi_enabled`` changes to False, then the hotspot will be killed.
 
 Astwifid Data Structures and Classes
 ------------------------------------
 
+.. autoclass:: astoria.common.config.system.WiFiInfo
+   :members:
+
 .. autoclass:: astoria.common.ipc.WiFiManagerMessage
    :members:
 
-.. autoclass:: astoria.astwifid.WiFiHotspotLifeCycle
+.. autoclass:: astoria.astwifid.lifecycle.AccessPointInfo
+   :members:
+
+.. autoclass:: astoria.astwifid.lifecycle.WiFiLifecycle
+   :members:
+
+.. autoclass:: astoria.astwifid.hotspot_lifecycle.WiFiHotspotLifeCycle
    :members:

--- a/tests/consumers/astwifid/test_wifi_hotspot_lifecycle.py
+++ b/tests/consumers/astwifid/test_wifi_hotspot_lifecycle.py
@@ -2,13 +2,13 @@
 
 import asyncio
 from pathlib import Path
-from typing import List, Tuple
 
 import pytest
 
 from astoria.astwifid.hotspot_lifecycle import WiFiHotspotLifeCycle
+from astoria.astwifid.lifecycle import AccessPointInfo
 from astoria.common.config import AstoriaConfig
-from astoria.common.metadata import Metadata
+from astoria.common.config.system import WiFiInfo
 
 
 class FakeHostapdWiFiHotspotLifeCycle(WiFiHotspotLifeCycle):
@@ -29,12 +29,8 @@ def config() -> AstoriaConfig:
 def lifecycle() -> WiFiHotspotLifeCycle:
     """Get an instance of the WiFiHotspotLifeCycle."""
     return FakeHostapdWiFiHotspotLifeCycle(
-        "ssid",
-        "pskpskpskpsk",
-        "region",
-        "interface",
-        "bridge",
-        True,
+        AccessPointInfo("ssid", "pskpskpskpsk", "region"),
+        WiFiInfo(interface="interface", bridge="bridge", enable_wpa3=True),
     )
 
 
@@ -47,11 +43,11 @@ def valid_hostapd_config() -> str:
 
 def test_wifi_hotspot_lifecycle_constructor(lifecycle: WiFiHotspotLifeCycle) -> None:
     """Test that we can construct a WiFiHotspotLifeCycle."""
-    assert lifecycle._ssid == "ssid"
-    assert lifecycle._psk == "pskpskpskpsk"
-    assert lifecycle._region == "region"
-    assert lifecycle._interface == "interface"
-    assert lifecycle._enable_wpa3 is True
+    assert lifecycle.access_point_info.ssid == "ssid"
+    assert lifecycle.access_point_info.psk == "pskpskpskpsk"
+    assert lifecycle.access_point_info.region == "region"
+    assert lifecycle.wifi_info.interface == "interface"
+    assert lifecycle.wifi_info.enable_wpa3 is True
 
 
 def test_wifi_hotspot_hostapd_config_generation(
@@ -60,7 +56,7 @@ def test_wifi_hotspot_hostapd_config_generation(
 ) -> None:
     """Test that we generate a hostapd config correctly."""
     assert lifecycle._config_file is None
-    lifecycle.generate_hostapd_config()
+    lifecycle._generate_hostapd_config()
     assert lifecycle._config_file is not None
 
     config_path = Path(lifecycle._config_file.name)
@@ -79,7 +75,7 @@ async def test_wifi_hotspot_start_stop(
 
     for _ in range(3):
         # Start it
-        asyncio.ensure_future(lifecycle.run_hotspot())
+        asyncio.ensure_future(lifecycle.run())
         await asyncio.sleep(0.02)
         assert lifecycle._proc is not None
         assert lifecycle._config_file is not None  # Should generate the config
@@ -87,33 +83,8 @@ async def test_wifi_hotspot_start_stop(
         assert lifecycle._running
 
         # Stop it
-        await lifecycle.stop_hotspot()
+        await lifecycle.stop()
         assert not lifecycle._running
         assert lifecycle._proc is None
         assert lifecycle._config_file is not None
         assert not config_file.exists()
-
-
-METADATA_TEST_CASES: List[Tuple[str, str, str, bool]] = [
-    ("ssid", "pskpskpskpsk", "region", False),
-    ("ssid2", "pskpskpskpsk", "region", True),
-    ("ssid", "pskpskpskpskpskpsk", "region", True),
-    ("ssid", "pskpskpskpsk", "otherregion", True),
-]
-
-
-@pytest.mark.parametrize("ssid,psk,region,outcome", METADATA_TEST_CASES)
-def test_wifi_hotspot_metadata_changed(
-        config: AstoriaConfig,
-        lifecycle: WiFiHotspotLifeCycle,
-        ssid: str,
-        psk: str,
-        region: str,
-        outcome: bool,
-) -> None:
-    """Test that we can check if metadata changes."""
-    metadata = Metadata.init(config)
-    metadata.wifi_ssid = ssid
-    metadata.wifi_psk = psk
-    metadata.wifi_region = region
-    assert lifecycle.has_metadata_changed(metadata) == outcome

--- a/tests/consumers/astwifid/test_wifi_hotspot_lifecycle.py
+++ b/tests/consumers/astwifid/test_wifi_hotspot_lifecycle.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 
 import pytest
 
-from astoria.astwifid import WiFiHotspotLifeCycle
+from astoria.astwifid.hotspot_lifecycle import WiFiHotspotLifeCycle
 from astoria.common.config import AstoriaConfig
 from astoria.common.metadata import Metadata
 


### PR DESCRIPTION
Refactor astwifid to enable multiple lifecycles.

This work is a prerequisite to adding support for WiFi client lifecycles and arena connectivity.

The refactor also adds a missing Lock, so eliminates an unhandled race condition.