### PR TITLE
Correct wifi channel

### DIFF
--- a/astoria/astwifid.py
+++ b/astoria/astwifid.py
@@ -210,7 +210,7 @@ class WiFiHotspotLifeCycle:
             "bridge": self._bridge,
             "ssid": self._ssid,
             "country_code": self._region,
-            "channel": 7,
+            "channel": 6,
             "hw_mode": "g",
             # Bit field: bit0 = WPA, bit1 = WPA2
             "wpa": 2,


### PR DESCRIPTION
The recommended wifi channels in Europe are 1, 6 and 11. Selecting other 2.4GHz channels will cause interference with other wifi networks, which will degrade performance.